### PR TITLE
keep_window_open(): Ignore input after cin error

### DIFF
--- a/std_lib_facilities.h
+++ b/std_lib_facilities.h
@@ -163,6 +163,7 @@ template<class T> char* as_bytes(T& i)	// needed for binary I/O
 inline void keep_window_open()
 {
 	cin.clear();
+	cin.ignore(120,'\n');
 	cout << "Please enter a character to exit\n";
 	char ch;
 	cin >> ch;


### PR DESCRIPTION
Update to the keep_window_open() function to make it work with Visual Studio 2017. The function needs to implement the same cin.clear() and cin.ignore() combination found in keep_window_open(string s). Otherwise, the function will immediately return because of data still in the input stream.